### PR TITLE
[Styling] Remove private property _priorityList in favor of making priority read-only

### DIFF
--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -17,8 +17,7 @@ namespace OwoAdvancedSensationBuilder.manager
 
         private Dictionary<string, AdvancedSensationStreamInstance> playSensations;
         private Dictionary<AdvancedSensationStreamInstance, ProcessState> processSensation;
-        private List<string> _priorityList;
-        public List<string> priorityList { get { return _priorityList; } }
+        public List<string> priorityList { get; }
 
         private int tick;
         private bool calculating;
@@ -35,7 +34,7 @@ namespace OwoAdvancedSensationBuilder.manager
 
             playSensations = new Dictionary<string, AdvancedSensationStreamInstance>();
             processSensation = new Dictionary<AdvancedSensationStreamInstance, ProcessState>();
-            _priorityList = new List<string>();
+            priorityList = new List<string>();
         }
 
         public static AdvancedSensationManager getInstance() {


### PR DESCRIPTION
Something I've missed in my other PR (#3): The value of `_priorityList`, so we can implement `priorityList` as a read-only property to improve legibility.

