### PR TITLE
Change `playSensations` to a `ConcurrentDictionary`

### DIFF
--- a/OwoAdvancedSensationBuilder.Demo/AdvancedDemoForm.cs
+++ b/OwoAdvancedSensationBuilder.Demo/AdvancedDemoForm.cs
@@ -98,10 +98,10 @@ namespace OwoAdvancedSensationBuilder {
             AdvancedSensationManager manager = AdvancedSensationManager.getInstance();
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance("Rain Snippet", getRandomRainSensation()).setLoop(true);
             instance.LastCalculationOfCycle += Instance_LastCalculationOfCycle;
-            instance.AfterAdd += (_, _) => updateVisualisationManager();
             instance.AfterRemove += (_, _) => updateVisualisationManager();
 
             manager.play(instance);
+            updateVisualisationManager();
         }
 
         private Sensation getRandomRainSensation() {
@@ -321,9 +321,9 @@ namespace OwoAdvancedSensationBuilder {
 
             AdvancedSensationManager manager = AdvancedSensationManager.getInstance();
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(selected, s);
-            instance.AfterAdd += (_, _) => updateVisualisationManager();
             instance.AfterRemove += (_, _) => updateVisualisationManager();
             manager.play(instance);
+            updateVisualisationManager();
         }
 
         private void btnLoopNow_Click(object sender, EventArgs e) {
@@ -332,9 +332,9 @@ namespace OwoAdvancedSensationBuilder {
 
             AdvancedSensationManager manager = AdvancedSensationManager.getInstance();
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(selected, s).setLoop(true);
-            instance.AfterAdd += (_, _) => updateVisualisationManager();
             instance.AfterRemove += (_, _) => updateVisualisationManager();
             manager.play(instance);
+            updateVisualisationManager();
         }
 
         private void btnStopNow_Click(object sender, EventArgs e) {

--- a/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
+++ b/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
@@ -550,7 +550,7 @@ namespace OwoAdvancedSensationBuilder.Demo {
         }
 
         private void interaction_toggleSensation(AdvancedSensationStreamInstance instance) {
-            if (AdvancedSensationManager.getInstance().getPlayingSensationInstances(true).ContainsKey(instance.name)) {
+            if (AdvancedSensationManager.getInstance().getPlayingSensationInstances().ContainsKey(instance.name)) {
                 AdvancedSensationManager.getInstance().stopSensation(instance.name);
             } else {
                 interaction_playSensation(instance);
@@ -558,7 +558,7 @@ namespace OwoAdvancedSensationBuilder.Demo {
         }
 
         private void interaction_toggleSensationLoopFinish(AdvancedSensationStreamInstance instance) {
-            if (AdvancedSensationManager.getInstance().getPlayingSensationInstances(true).ContainsKey(instance.name)) {
+            if (AdvancedSensationManager.getInstance().getPlayingSensationInstances().ContainsKey(instance.name)) {
                 interaction_stopLooping(instance.name);
             } else {
                 interaction_playSensation(instance);
@@ -566,7 +566,7 @@ namespace OwoAdvancedSensationBuilder.Demo {
         }
 
         private void interaction_toggleSensationSliderLoop(Sensation sensation, string name, TrackBar slider) {
-            if (AdvancedSensationManager.getInstance().getPlayingSensationInstances(true).ContainsKey(name)) {
+            if (AdvancedSensationManager.getInstance().getPlayingSensationInstances().ContainsKey(name)) {
                 interaction_stopLooping(name);
             } else {
                 AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(name, sensation)

--- a/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
+++ b/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
@@ -507,9 +507,9 @@ namespace OwoAdvancedSensationBuilder.Demo {
 
         private void interaction_playSensation(params AdvancedSensationStreamInstance[] instances) {
             foreach (AdvancedSensationStreamInstance instance in instances) {
-                instance.AfterAdd += Instance_AfterAdd;
                 instance.AfterRemove += Instance_AfterRemove;
                 AdvancedSensationManager.getInstance().play(instance);
+                Instance_AfterAdd(instance, AddInfo.NEW);
             }
         }
 

--- a/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
+++ b/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
@@ -509,13 +509,13 @@ namespace OwoAdvancedSensationBuilder.Demo {
             foreach (AdvancedSensationStreamInstance instance in instances) {
                 instance.AfterRemove += Instance_AfterRemove;
                 AdvancedSensationManager.getInstance().play(instance);
-                Instance_AfterAdd(instance, AddInfo.NEW);
+                Instance_AfterAdd(instance);
             }
         }
 
-        private void Instance_AfterAdd(AdvancedSensationStreamInstance instance, AddInfo info) {
+        private void Instance_AfterAdd(AdvancedSensationStreamInstance instance) {
             if (lbManager.InvokeRequired) {
-                Action doInvoke = delegate { Instance_AfterAdd(instance, info); };
+                Action doInvoke = delegate { Instance_AfterAdd(instance); };
                 lbManager.Invoke(doInvoke);
                 return;
             }

--- a/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
+++ b/OwoAdvancedSensationBuilder.Demo/DemoForm.cs
@@ -45,8 +45,7 @@ namespace OwoAdvancedSensationBuilder.Demo {
 
             flowIntro.Controls.Add(new HeaderSection("The Builder"));
             flowIntro.Controls.Add(new TextSection("The Builder is the part that transforms a Sensation into an advanced Sensation. This includes " +
-                "transforming the actual intensity and the per Muscle intensity into the per muscle intensity as well as calculating the intensity in case of " +
-                "RampUp and RampDown."));
+                "transforming the actual intensity, the per Muscle intensity as well as calculating the intensity in case of RampUp and RampDown for each Muscle in the new advanced Sensation."));
             flowIntro.Controls.Add(new TextSection("Additionally it also allows to modify and combine Sensations."));
 
             flowIntro.Controls.Add(new HeaderSection("The Manager"));
@@ -125,7 +124,7 @@ namespace OwoAdvancedSensationBuilder.Demo {
                 "AdvancedSensationManager.getInstance().playOnce(sensation);\r\n" +
                 "AdvancedSensationManager.getInstance().stopAll();"));
 
-            flowFeatures.Controls.Add(new TextSection("Do keep in mind though, that OWO (currently) wont allow to load BakedSensations by Code and thus can't " +
+            flowFeatures.Controls.Add(new TextSection("Do keep in mind though, that OWO (currently) won't allow to load BakedSensations by Code and thus can't " +
                 "play those by the Manager. If your usecase requires BakedSensations the Manager may require heavy planning. Should OWO ever decide to make " +
                 "BakedSensations loadable by Code this probably wouldn't be a problem anymore."));
 
@@ -382,28 +381,26 @@ namespace OwoAdvancedSensationBuilder.Demo {
             flowFeatures.Controls.Add(new HeaderSection("Event handling"));
             flowFeatures.Controls.Add(new TextSection("The Instance offeres multiple Events, which can eg. help to modify the Sensation or Sync up the Sensations " +
                 "with external Code more easily."));
-            flowFeatures.Controls.Add(new TextSection("AfterAdd is called after a Sensation is added. If the manager is already running it could take up to 0.1 " +
-                "Seconds. If you add multiple Instances with the same name at once it could happen that you wont get the same count of events as play calls, " +
-                "as you can't add multiple Sensations of the same name in the same manager tick. Following Instances will either get ignored or overwrite the " +
-                "queued Instance. AddInfo contains information of if the Instance got newly added or replaced an existing Instance."));
             flowFeatures.Controls.Add(new TextSection("AfterUpdate is called after a Sensation is updated."));
             flowFeatures.Controls.Add(new TextSection("AfterRemove is called after a Sensation is removed. RemoveInfo contains information of if the Instance " +
-                "got removed manually, finished playing or if it got replaced by a new play call"));
+                "got removed manually, finished playing or if it got replaced by a new play call."));
             flowFeatures.Controls.Add(new TextSection("LastCalculationOfCycle is called right before the last part of the Sensation is played. For looping " +
                 "Sensations this gets called on every loop. It could for example trigger an update for randomized Sensations like rain. " +
-                "In case of looped Sensation it takes about 0.1 seconds before the loop starts from the beginning and calling an update or a remove wont affect " +
+                "In case of looped Sensation it takes about 0.1 seconds before the loop starts from the beginning and calling an update or a remove won't affect " +
                 "this last Sensation part, but the next one to be played when it restarts."));
+            flowFeatures.Controls.Add(new TextSection("OnFirstSensationTick is called after a Sensation started playing. For looping Sensations this gets called on every loop. " +
+                "If the manager is already running it could take up to 0.1 Seconds, between adding and triggering this event. " +
+                "If you add multiple Instances with the same name at once it could happen that you won't get the same count of events as play calls, " +
+                "as you can't add multiple Sensations of the same name in the same manager tick. Following Instances will either get ignored or overwrite the queued Instance. " +
+                "As looping Sensations call this Event on each repeat, the boolean 'firstCycle' provides Information regarding of if this would be the first time the event triggered for this Sensation. " +
+                "Just as LastCalculationOfCycle, changes to this instance won't be reflected until the next Tick."));
+
             flowFeatures.Controls.Add(new CodeSection(
                 "public void prepareInstanceEvents(AdvancedSensationStreamInstance instance) {\r\n" +
-                "    instance.AfterAdd += Instance_AfterAdd;\r\n" +
                 "    instance.AfterUpdate += Instance_AfterUpdate;\r\n" +
                 "    instance.AfterRemove += Instance_AfterRemove;\r\n" +
                 "    instance.LastCalculationOfCycle += Instance_LastCalculationOfCycle;\r\n" +
-                "}\r\n" +
-                "\r\n" +
-                "private void Instance_AfterAdd(AdvancedSensationStreamInstance instance, AddInfo info) {\r\n" +
-                "    // AddInfo can bei either NEW or REPLACE\r\n" +
-                "    throw new NotImplementedException();\r\n" +
+                "    instance.OnFirstSensationTick += Instance_OnFirstSensationTick;\r\n" +
                 "}\r\n" +
                 "\r\n" +
                 "private void Instance_AfterUpdate(AdvancedSensationStreamInstance instance) {\r\n" +
@@ -417,6 +414,10 @@ namespace OwoAdvancedSensationBuilder.Demo {
                 "\r\n" +
                 "private void Instance_LastCalculationOfCycle(AdvancedSensationStreamInstance instance) {\r\n" +
                 "    throw new NotImplementedException();\r\n" +
+                "}\r\n" +
+                "\r\n" +
+                "private void Inst_OnFirstSensationTick(AdvancedSensationStreamInstance instance, bool firstCycle) {\r\n" +
+                "   throw new NotImplementedException();\r\n" +
                 "}"));
 
             flowFeatures.Controls.Add(new TextSection("Events can help you to schedule changes in the Sensation. In these cases it is likley that you don't " +

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -215,8 +215,9 @@ namespace OwoAdvancedSensationBuilder.manager
             Debug.WriteLine(System.DateTime.Now.Millisecond + " - resetManagerState");
             timer.Stop();
             tick = 0;
-            // cancel the last sensation
-            OWO.Send(SensationsFactory.Create(0, 0, 0, 0, 0, 1));
+
+            // Cancel all sensations
+            OWO.Stop();
         }
 
         /// <summary>

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -55,13 +55,14 @@ namespace OwoAdvancedSensationBuilder.manager
                 streamSensation();
                 return;
             }
+
+            if (playSensations.IsEmpty) {
+                resetManagerState();
+                return;
+            }
+
             try {
                 calculating = true;
-
-                if (playSensations.Count == 0) {
-                    resetManagerState();
-                    return;
-                }
 
                 calcSensation();
                 streamSensation();

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -188,7 +188,6 @@ namespace OwoAdvancedSensationBuilder.manager
 
                 //playSensations.TryRemove(oldInstance); // Already removed by AddOrUpdate later
                 oldInstance.triggerRemoveEvent(RemoveInfo.REPLACED);
-                info = AddInfo.REPLACE;
             }
 
             playSensations.AddOrUpdate(instance.name, instance, (key, oldValue) => instance);

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -206,8 +206,8 @@ namespace OwoAdvancedSensationBuilder.manager
         /// Stops all Sensation.
         /// </summary>
         public void stopAll() {
-            resetManagerState();
             playSensations.Clear();
+            resetManagerState();
         }
 
         private void resetManagerState() {

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -1,10 +1,10 @@
 ﻿using OwoAdvancedSensationBuilder.builder;
 using System.Diagnostics;
-using System.Timers;
 using OWOGame;
 using static OwoAdvancedSensationBuilder.builder.AdvancedSensationMergeOptions;
 using OwoAdvancedSensationBuilder.exceptions;
 using static OwoAdvancedSensationBuilder.manager.AdvancedSensationStreamInstance;
+using System.Collections.Concurrent;
 
 namespace OwoAdvancedSensationBuilder.manager
 {
@@ -16,8 +16,7 @@ namespace OwoAdvancedSensationBuilder.manager
 
         private System.Timers.Timer timer;
 
-        private Dictionary<string, AdvancedSensationStreamInstance> playSensations;
-        private Dictionary<AdvancedSensationStreamInstance, ProcessState> processSensation;
+        private ConcurrentDictionary<string, AdvancedSensationStreamInstance> playSensations;
 
         private int tick;
         private bool calculating;
@@ -31,8 +30,7 @@ namespace OwoAdvancedSensationBuilder.manager
             timer.AutoReset = true;
             timer.Enabled = false;
 
-            playSensations = new Dictionary<string, AdvancedSensationStreamInstance>();
-            processSensation = new Dictionary<AdvancedSensationStreamInstance, ProcessState>();
+            playSensations = new ConcurrentDictionary<string, AdvancedSensationStreamInstance>();
         }
 
         public static AdvancedSensationManager getInstance() {
@@ -59,9 +57,6 @@ namespace OwoAdvancedSensationBuilder.manager
             }
             try {
                 calculating = true;
-                processRemove();
-                processUpdate();
-                processAdd();
 
                 if (playSensations.Count == 0) {
                     resetManagerState();
@@ -72,68 +67,6 @@ namespace OwoAdvancedSensationBuilder.manager
                 streamSensation();
             } finally {
                 calculating = false;
-            }
-        }
-
-        private void processUpdate() {
-            KeyValuePair<AdvancedSensationStreamInstance, ProcessState>[] processSensationList = processSensation.ToArray();
-
-            // Create a dictionary of instances with the status ADD to speed up the lookup of instances int the next loop
-            Dictionary<string, AdvancedSensationStreamInstance> instancesToAdd = new();
-            foreach (var process in processSensationList.Where(entry => entry.Value == ProcessState.ADD)) {
-                instancesToAdd.TryAdd(process.Key.name, process.Key); //TODO: process.Key.name could be an empty string which could cause problems with collisions
-            }
-
-            foreach (var process in processSensationList.Where(entry => entry.Value == ProcessState.UPDATE)) {
-                AdvancedSensationStreamInstance instance = process.Key;
-                AdvancedSensationStreamInstance? oldInstance = null;
-
-                if (playSensations.ContainsKey(instance.name)) {
-                    // Update Playing Sensation
-                    oldInstance = playSensations[instance.name];
-                } else {
-                    // Update Sensation thats not added yet
-                    // Would trigger Update event before Add event
-                    oldInstance = instancesToAdd.GetValueOrDefault(instance.name);
-                }
-
-                oldInstance?.updateSensation(instance.sensation, tick);
-
-                processSensation.Remove(process.Key);
-            }
-        }
-
-        private void processAdd() {
-            foreach (var process in processSensation.ToArray().Where(entry => entry.Value == ProcessState.ADD)) {
-                AdvancedSensationStreamInstance instance = process.Key;
-                instance.firstTick = tick;
-
-                AddInfo info = AddInfo.NEW;
-                if (playSensations.ContainsKey(instance.name)) {
-                    AdvancedSensationStreamInstance oldInstance = playSensations[instance.name];
-                    playSensations.Remove(instance.name);
-                    oldInstance.triggerRemoveEvent(RemoveInfo.REPLACED);
-                    info = AddInfo.REPLACE;
-                }
-
-                playSensations[instance.name] = instance;
-                instance.triggerAddEvent(info);
-
-                processSensation.Remove(process.Key);
-            }
-        }
-
-        private void processRemove() {
-            foreach (var process in processSensation.ToArray().Where(entry => entry.Value == ProcessState.REMOVE)) {
-                AdvancedSensationStreamInstance instance = process.Key;
-
-                if (playSensations.ContainsKey(instance.name)) {
-                    AdvancedSensationStreamInstance oldInstance = playSensations[instance.name];
-                    playSensations.Remove(instance.name);
-                    oldInstance.triggerRemoveEvent(RemoveInfo.MANUAL);
-                }
-
-                processSensation.Remove(process.Key);
             }
         }
 
@@ -173,9 +106,7 @@ namespace OwoAdvancedSensationBuilder.manager
                 blockFurtherSensations |= sensationInstance.blockLowerPrio;
 
                 if (sensationInstance.isLastTickOfCycle(calcTick) && !sensationInstance.loop) {
-                    AdvancedSensationStreamInstance oldInstance = playSensations[entry.Key];
-                    playSensations.Remove(entry.Key);
-                    oldInstance.triggerRemoveEvent(RemoveInfo.FINISHED);
+                    RemoveInstanceFromManager(sensationInstance);
                 }
             }
 
@@ -221,7 +152,11 @@ namespace OwoAdvancedSensationBuilder.manager
             if (name == null) {
                 name = analyzeSensation(sensation).name;
             }
-            processSensation[new AdvancedSensationStreamInstance(name, sensation)] = ProcessState.UPDATE;
+
+            if (!playSensations.TryGetValue(name, out AdvancedSensationStreamInstance? existingInstance)) {
+                return;
+            }
+            existingInstance?.updateSensation(sensation, tick);
         }
 
         /// <summary>
@@ -234,16 +169,31 @@ namespace OwoAdvancedSensationBuilder.manager
         }
 
         private void RemoveInstanceFromManager(AdvancedSensationStreamInstance instance) {
-            if (instance.name != null && (!processSensation.ContainsKey(instance) || instance.overwriteManagerProcessList)) {
-                processSensation[instance] = ProcessState.REMOVE;
+            if (instance.name == null) {
+                return;
+            }
+
+            //TODO: Implement OverwriteProcessList
+            playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance);
+
+            if (removedInstance != null) {
+                removedInstance.triggerRemoveEvent(RemoveInfo.MANUAL);
             }
         }
 
         private void addSensationInstance(AdvancedSensationStreamInstance instance) {
-            if (!processSensation.ContainsKey(instance) || instance.overwriteManagerProcessList) {
-                instance.timeStamp = DateTime.Now.Ticks;
-                processSensation[instance] = ProcessState.ADD;
+            instance.firstTick = tick;
+
+            //TODO: Implement overwriteManagerProcessList
+            AddInfo info = AddInfo.NEW;
+            if (playSensations.TryGetValue(instance.name, out AdvancedSensationStreamInstance? oldInstance) && oldInstance != null) {
+                //playSensations.TryRemove(oldInstance); // Already removed by AddOrUpdate later
+                oldInstance.triggerRemoveEvent(RemoveInfo.REPLACED);
+                info = AddInfo.REPLACE;
             }
+
+            playSensations.AddOrUpdate(instance.name, instance, (key, oldValue) => instance);
+            instance.triggerAddEvent(info);
 
             if (!timer.Enabled) {
                 watch = Stopwatch.StartNew();
@@ -257,7 +207,6 @@ namespace OwoAdvancedSensationBuilder.manager
         public void stopAll() {
             resetManagerState();
             playSensations.Clear();
-            processSensation.Clear();
         }
 
         private void resetManagerState() {
@@ -272,19 +221,8 @@ namespace OwoAdvancedSensationBuilder.manager
         /// Returns a dictionary with the Names and the actual Instances in the Manager.
         /// By default it also returns Entries that are not yet playing, but scheduled to be added in the next tick.
         /// </summary>
-        public Dictionary<string, AdvancedSensationStreamInstance> getPlayingSensationInstances(bool addPlanned = true) {
-            Dictionary<string, AdvancedSensationStreamInstance> returnInstances = new Dictionary<string, AdvancedSensationStreamInstance>();
-            foreach (var playInstance in playSensations) {
-                returnInstances[playInstance.Key] = playInstance.Value;
-            }
-            if (addPlanned) {
-                foreach (var processInstance in processSensation) {
-                    if (processInstance.Value == ProcessState.ADD) {
-                        returnInstances[processInstance.Key.name] = processInstance.Key;
-                    }
-                }
-            }
-            return returnInstances;
+        public Dictionary<string, AdvancedSensationStreamInstance> getPlayingSensationInstances() {
+            return playSensations.ToDictionary();
         }
 
         private MicroSensation analyzeSensation(Sensation sensation) {

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -10,8 +10,6 @@ namespace OwoAdvancedSensationBuilder.manager
 {
     public class AdvancedSensationManager {
 
-        public enum ProcessState { ADD, REMOVE, UPDATE }
-
         private static AdvancedSensationManager? managerInstance;
 
         private readonly System.Timers.Timer timer;
@@ -195,7 +193,6 @@ namespace OwoAdvancedSensationBuilder.manager
             }
 
             playSensations.AddOrUpdate(instance.name, instance, (key, oldValue) => instance);
-            instance.triggerAddEvent(info);
 
             if (!timer.Enabled) {
                 watch = Stopwatch.StartNew();

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -181,7 +181,6 @@ namespace OwoAdvancedSensationBuilder.manager
         private void addSensationInstance(AdvancedSensationStreamInstance instance) {
             instance.firstTick = tick;
 
-            AddInfo info = AddInfo.NEW;
             if (playSensations.TryGetValue(instance.name, out AdvancedSensationStreamInstance? oldInstance) && oldInstance != null) {
                 if (!instance.replaceRunning) {
                     return;

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -14,9 +14,9 @@ namespace OwoAdvancedSensationBuilder.manager
 
         private static AdvancedSensationManager? managerInstance;
 
-        private System.Timers.Timer timer;
+        private readonly System.Timers.Timer timer;
 
-        private ConcurrentDictionary<string, AdvancedSensationStreamInstance> playSensations;
+        private readonly ConcurrentDictionary<string, AdvancedSensationStreamInstance> playSensations;
 
         private int tick;
         private bool calculating;
@@ -246,6 +246,5 @@ namespace OwoAdvancedSensationBuilder.manager
             string typeName = sensation.GetType().Name;
             throw new AdvancedSensationException($"Unsupported Sensation type: {typeName}");
         }
-
     }
 }

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -164,7 +164,6 @@ namespace OwoAdvancedSensationBuilder.manager
         /// </summary>
         public void stopSensation(string sensationInstanceName) {
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(sensationInstanceName, SensationsFactory.Create(0, 0, 0)); // Using an empty sensation as the instance is only used for removal. In this case, the sensation property will not be used
-            instance.overwriteManagerProcessList = true;
             RemoveInstanceFromManager(instance);
         }
 
@@ -173,7 +172,6 @@ namespace OwoAdvancedSensationBuilder.manager
                 return;
             }
 
-            //TODO: Implement OverwriteProcessList
             playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance);
 
             if (removedInstance != null) {
@@ -184,9 +182,12 @@ namespace OwoAdvancedSensationBuilder.manager
         private void addSensationInstance(AdvancedSensationStreamInstance instance) {
             instance.firstTick = tick;
 
-            //TODO: Implement overwriteManagerProcessList
             AddInfo info = AddInfo.NEW;
             if (playSensations.TryGetValue(instance.name, out AdvancedSensationStreamInstance? oldInstance) && oldInstance != null) {
+                if (!instance.replaceRunning) {
+                    return;
+                }
+
                 //playSensations.TryRemove(oldInstance); // Already removed by AddOrUpdate later
                 oldInstance.triggerRemoveEvent(RemoveInfo.REPLACED);
                 info = AddInfo.REPLACE;

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -121,8 +121,8 @@ namespace OwoAdvancedSensationBuilder.manager
         /// The name of the Sensation will be used internally. If empty a random name will be generated.
         /// Overrides Instances with the same Name and starts at the begining of the Sensation.
         /// </summary>
-        public void playOnce(Sensation sensation) {
-            play(new AdvancedSensationStreamInstance(analyzeSensation(sensation).name, sensation));
+        public bool playOnce(Sensation sensation) {
+            return play(new AdvancedSensationStreamInstance(analyzeSensation(sensation).name, sensation));
         }
 
         /// <summary>
@@ -131,56 +131,61 @@ namespace OwoAdvancedSensationBuilder.manager
         /// The name of the Sensation will be used internally. If empty a random name will be generated.
         /// Overrides Instances with the same Name and starts at the begining of the Sensation.
         /// </summary>
-        public void playLoop(Sensation sensation) {
-            play(new AdvancedSensationStreamInstance(analyzeSensation(sensation).name, sensation).setLoop(true));
+        public bool playLoop(Sensation sensation) {
+            return play(new AdvancedSensationStreamInstance(analyzeSensation(sensation).name, sensation).setLoop(true));
         }
 
         /// <summary>
         /// Adds the AdvancedSensationStreamInstance of an advanced Sensation to the Manager.
         /// Overrides Instances with the same Name and starts at the begining of the Sensation.
         /// </summary>
-        public void play(AdvancedSensationStreamInstance instance) {
-            addSensationInstance(instance);
+        public bool play(AdvancedSensationStreamInstance instance) {
+            return addSensationInstance(instance);
         }
 
         /// <summary>
         /// Changes the Sensation of a given AdvancedSensationStreamInstance, without starting it new, but continuing where it currently is.
         /// If no name is provided the name of the Sensation will be used.
         /// </summary>
-        public void updateSensation(Sensation sensation, string? name = null) {
+        public bool updateSensation(Sensation sensation, string? name = null) {
             if (name == null) {
                 name = analyzeSensation(sensation).name;
             }
 
             if (playSensations.TryGetValue(name, out AdvancedSensationStreamInstance? existingInstance)) {
                 existingInstance?.updateSensation(sensation, tick);
+                return true;
             }
+
+            return false;
         }
 
         /// <summary>
         /// Stops a Sensation with a given name.
         /// </summary>
-        public void stopSensation(string sensationInstanceName) {
+        public bool stopSensation(string sensationInstanceName) {
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(sensationInstanceName, SensationsFactory.Create(0, 0, 0)); // Using an empty sensation as the instance is only used for removal. In this case, the sensation property will not be used
-            removeInstanceFromManager(instance, RemoveInfo.MANUAL);
+            return removeInstanceFromManager(instance, RemoveInfo.MANUAL);
         }
 
-        private void removeInstanceFromManager(AdvancedSensationStreamInstance instance, RemoveInfo removeInfo) {
+        private bool removeInstanceFromManager(AdvancedSensationStreamInstance instance, RemoveInfo removeInfo) {
             if (instance.name == null) {
-                return;
+                return false;
             }
 
             if (playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance)) {
                 removedInstance.triggerRemoveEvent(removeInfo);
+                return true;
             }
+            return false;
         }
 
-        private void addSensationInstance(AdvancedSensationStreamInstance instance) {
+        private bool addSensationInstance(AdvancedSensationStreamInstance instance) {
             instance.firstTick = tick;
 
             if (playSensations.TryGetValue(instance.name, out AdvancedSensationStreamInstance? oldInstance) && oldInstance != null) {
                 if (!instance.replaceRunning) {
-                    return;
+                    return false;
                 }
 
                 //playSensations.TryRemove(oldInstance); // Already removed by AddOrUpdate later
@@ -193,6 +198,7 @@ namespace OwoAdvancedSensationBuilder.manager
                 watch = Stopwatch.StartNew();
                 timer.Start();
             }
+            return true;
         }
 
         /// <summary>

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -120,6 +120,7 @@ namespace OwoAdvancedSensationBuilder.manager
         /// Transforms Sensation into an advanced Sensation and adds it to the Manager.
         /// The name of the Sensation will be used internally. If empty a random name will be generated.
         /// Overrides Instances with the same Name and starts at the begining of the Sensation.
+        /// Returns if the Sensation was added, which should always be true in this case.
         /// </summary>
         public bool playOnce(Sensation sensation) {
             return play(new AdvancedSensationStreamInstance(analyzeSensation(sensation).name, sensation));
@@ -130,6 +131,7 @@ namespace OwoAdvancedSensationBuilder.manager
         /// Transforms Sensation into an advanced Sensation and adds it looping to the Manager.
         /// The name of the Sensation will be used internally. If empty a random name will be generated.
         /// Overrides Instances with the same Name and starts at the begining of the Sensation.
+        /// Returns if the Sensation was added, which should always be true in this case.
         /// </summary>
         public bool playLoop(Sensation sensation) {
             return play(new AdvancedSensationStreamInstance(analyzeSensation(sensation).name, sensation).setLoop(true));
@@ -137,7 +139,8 @@ namespace OwoAdvancedSensationBuilder.manager
 
         /// <summary>
         /// Adds the AdvancedSensationStreamInstance of an advanced Sensation to the Manager.
-        /// Overrides Instances with the same Name and starts at the begining of the Sensation.
+        /// May override Instances with the same Name and starts at the begining of the Sensation when added.
+        /// Returns if the Sensation was added, depending on instance.replaceRunning.
         /// </summary>
         public bool play(AdvancedSensationStreamInstance instance) {
             return addSensationInstance(instance);
@@ -146,14 +149,15 @@ namespace OwoAdvancedSensationBuilder.manager
         /// <summary>
         /// Changes the Sensation of a given AdvancedSensationStreamInstance, without starting it new, but continuing where it currently is.
         /// If no name is provided the name of the Sensation will be used.
+        /// Returns if a Sensation was updated.
         /// </summary>
         public bool updateSensation(Sensation sensation, string? name = null) {
             if (name == null) {
                 name = analyzeSensation(sensation).name;
             }
 
-            if (playSensations.TryGetValue(name, out AdvancedSensationStreamInstance? existingInstance)) {
-                existingInstance?.updateSensation(sensation, tick);
+            if (playSensations.TryGetValue(name, out AdvancedSensationStreamInstance? existingInstance) && existingInstance != null) {
+                existingInstance.updateSensation(sensation, tick);
                 return true;
             }
 
@@ -162,6 +166,7 @@ namespace OwoAdvancedSensationBuilder.manager
 
         /// <summary>
         /// Stops a Sensation with a given name.
+        /// Returns if a Sensation was stopped.
         /// </summary>
         public bool stopSensation(string sensationInstanceName) {
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(sensationInstanceName, SensationsFactory.Create(0, 0, 0)); // Using an empty sensation as the instance is only used for removal. In this case, the sensation property will not be used
@@ -173,7 +178,7 @@ namespace OwoAdvancedSensationBuilder.manager
                 return false;
             }
 
-            if (playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance)) {
+            if (playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance) && removedInstance != null) {
                 removedInstance.triggerRemoveEvent(removeInfo);
                 return true;
             }
@@ -182,6 +187,7 @@ namespace OwoAdvancedSensationBuilder.manager
 
         private bool addSensationInstance(AdvancedSensationStreamInstance instance) {
             instance.firstTick = tick;
+            instance.timeStamp = DateTime.Now.Ticks;
 
             if (playSensations.TryGetValue(instance.name, out AdvancedSensationStreamInstance? oldInstance) && oldInstance != null) {
                 if (!instance.replaceRunning) {
@@ -220,7 +226,6 @@ namespace OwoAdvancedSensationBuilder.manager
 
         /// <summary>
         /// Returns a dictionary with the Names and the actual Instances in the Manager.
-        /// By default it also returns Entries that are not yet playing, but scheduled to be added in the next tick.
         /// </summary>
         public Dictionary<string, AdvancedSensationStreamInstance> getPlayingSensationInstances() {
             return playSensations.ToDictionary();

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -105,7 +105,7 @@ namespace OwoAdvancedSensationBuilder.manager
                 blockFurtherSensations |= sensationInstance.blockLowerPrio;
 
                 if (sensationInstance.isLastTickOfCycle(calcTick) && !sensationInstance.loop) {
-                    removeInstanceFromManager(sensationInstance);
+                    removeInstanceFromManager(sensationInstance, RemoveInfo.FINISHED);
                 }
             }
 
@@ -162,16 +162,16 @@ namespace OwoAdvancedSensationBuilder.manager
         /// </summary>
         public void stopSensation(string sensationInstanceName) {
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(sensationInstanceName, SensationsFactory.Create(0, 0, 0)); // Using an empty sensation as the instance is only used for removal. In this case, the sensation property will not be used
-            removeInstanceFromManager(instance);
+            removeInstanceFromManager(instance, RemoveInfo.MANUAL);
         }
 
-        private void removeInstanceFromManager(AdvancedSensationStreamInstance instance) {
+        private void removeInstanceFromManager(AdvancedSensationStreamInstance instance, RemoveInfo removeInfo) {
             if (instance.name == null) {
                 return;
             }
 
             if (playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance)) {
-                removedInstance.triggerRemoveEvent(RemoveInfo.MANUAL);
+                removedInstance.triggerRemoveEvent(removeInfo);
             }
         }
 

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationManager.cs
@@ -105,7 +105,7 @@ namespace OwoAdvancedSensationBuilder.manager
                 blockFurtherSensations |= sensationInstance.blockLowerPrio;
 
                 if (sensationInstance.isLastTickOfCycle(calcTick) && !sensationInstance.loop) {
-                    RemoveInstanceFromManager(sensationInstance);
+                    removeInstanceFromManager(sensationInstance);
                 }
             }
 
@@ -152,10 +152,9 @@ namespace OwoAdvancedSensationBuilder.manager
                 name = analyzeSensation(sensation).name;
             }
 
-            if (!playSensations.TryGetValue(name, out AdvancedSensationStreamInstance? existingInstance)) {
-                return;
+            if (playSensations.TryGetValue(name, out AdvancedSensationStreamInstance? existingInstance)) {
+                existingInstance?.updateSensation(sensation, tick);
             }
-            existingInstance?.updateSensation(sensation, tick);
         }
 
         /// <summary>
@@ -163,17 +162,15 @@ namespace OwoAdvancedSensationBuilder.manager
         /// </summary>
         public void stopSensation(string sensationInstanceName) {
             AdvancedSensationStreamInstance instance = new AdvancedSensationStreamInstance(sensationInstanceName, SensationsFactory.Create(0, 0, 0)); // Using an empty sensation as the instance is only used for removal. In this case, the sensation property will not be used
-            RemoveInstanceFromManager(instance);
+            removeInstanceFromManager(instance);
         }
 
-        private void RemoveInstanceFromManager(AdvancedSensationStreamInstance instance) {
+        private void removeInstanceFromManager(AdvancedSensationStreamInstance instance) {
             if (instance.name == null) {
                 return;
             }
 
-            playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance);
-
-            if (removedInstance != null) {
+            if (playSensations.TryRemove(instance.name, out AdvancedSensationStreamInstance? removedInstance)) {
                 removedInstance.triggerRemoveEvent(RemoveInfo.MANUAL);
             }
         }

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
@@ -13,7 +13,6 @@ namespace OwoAdvancedSensationBuilder.manager {
         public enum RemoveInfo { MANUAL, FINISHED, REPLACED }
 
         public event SensationStreamInstanceEvent? LastCalculationOfCycle;
-        public event SensationStreamInstanceAddEvent? AfterAdd;
         public event SensationStreamInstanceEvent? AfterUpdate;
         public event SensationStreamInstanceRemoveEvent? AfterRemove;
 
@@ -68,10 +67,6 @@ namespace OwoAdvancedSensationBuilder.manager {
             firstTick = tick - ((tick - firstTick) % sensation.sensations.Count);
             sensation = new AdvancedSensationBuilder(newSensation).getSensationForStream();
             AfterUpdate?.Invoke(this);
-        }
-
-        internal void triggerAddEvent(AddInfo info) {
-            AfterAdd?.Invoke(this, info);
         }
 
         internal void triggerRemoveEvent(RemoveInfo info) {

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
@@ -19,14 +19,14 @@ namespace OwoAdvancedSensationBuilder.manager {
 
         public string name { get; }
         internal int firstTick { get; set; }
-        internal bool overwriteManagerProcessList { get; set; }
+        internal bool replaceRunning { get; set; }
         public bool loop { get; set; }
         public bool blockLowerPrio { get; set; }
         public long timeStamp { get; internal set; }
 
         public AdvancedStreamingSensation sensation { get; private set; }
 
-        public AdvancedSensationStreamInstance(string name, Sensation sensation, bool overwriteManagerProcessList = false) {
+        public AdvancedSensationStreamInstance(string name, Sensation sensation, bool replaceRunning = true) {
             if (String.IsNullOrWhiteSpace(name)) {
                 this.name = Guid.NewGuid().ToString();
             } else {
@@ -35,7 +35,7 @@ namespace OwoAdvancedSensationBuilder.manager {
             loop = false;
             blockLowerPrio = false;
             firstTick = 0;
-            this.overwriteManagerProcessList = overwriteManagerProcessList;
+            this.replaceRunning = replaceRunning;
 
             this.sensation = new AdvancedSensationBuilder(sensation).getSensationForStream();
         }

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
@@ -6,18 +6,19 @@ namespace OwoAdvancedSensationBuilder.manager {
     public class AdvancedSensationStreamInstance {
 
         public delegate void SensationStreamInstanceEvent(AdvancedSensationStreamInstance instance);
-        public delegate void SensationStreamInstanceAddEvent(AdvancedSensationStreamInstance instance, AddInfo info);
+        public delegate void SensationStreamInstanceFirstCycleEvent(AdvancedSensationStreamInstance instance);
         public delegate void SensationStreamInstanceRemoveEvent(AdvancedSensationStreamInstance instance, RemoveInfo info);
 
-        public enum AddInfo { NEW, REPLACE }
         public enum RemoveInfo { MANUAL, FINISHED, REPLACED }
 
         public event SensationStreamInstanceEvent? LastCalculationOfCycle;
         public event SensationStreamInstanceEvent? AfterUpdate;
         public event SensationStreamInstanceRemoveEvent? AfterRemove;
+        public event SensationStreamInstanceFirstCycleEvent? OnFirstCycle;
 
         public string name { get; }
         internal int firstTick { get; set; }
+        internal bool isFirstCalculationCycle { get; set; }
         internal bool replaceRunning { get; set; }
         public bool loop { get; set; }
         public bool blockLowerPrio { get; set; }
@@ -34,6 +35,7 @@ namespace OwoAdvancedSensationBuilder.manager {
             loop = false;
             blockLowerPrio = false;
             firstTick = 0;
+            isFirstCalculationCycle = true;
             this.replaceRunning = replaceRunning;
 
             this.sensation = new AdvancedSensationBuilder(sensation).getSensationForStream();
@@ -42,6 +44,12 @@ namespace OwoAdvancedSensationBuilder.manager {
         internal SensationWithMuscles? getSensationAtTick(int tick) {
             if (sensation.isEmpty()) {
                 return null;
+            }
+
+            if (isFirstCalculationCycle)
+            {
+                isFirstCalculationCycle = false;
+                OnFirstCycle?.Invoke(this);
             }
 
             int playedSensation = (tick - firstTick) % sensation.sensations.Count;

--- a/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
+++ b/OwoAdvancedSensationBuilder/manager/AdvancedSensationStreamInstance.cs
@@ -6,7 +6,7 @@ namespace OwoAdvancedSensationBuilder.manager {
     public class AdvancedSensationStreamInstance {
 
         public delegate void SensationStreamInstanceEvent(AdvancedSensationStreamInstance instance);
-        public delegate void SensationStreamInstanceFirstCycleEvent(AdvancedSensationStreamInstance instance);
+        public delegate void SensationStreamInstanceSensationTickEvent(AdvancedSensationStreamInstance instance, bool firstCycle);
         public delegate void SensationStreamInstanceRemoveEvent(AdvancedSensationStreamInstance instance, RemoveInfo info);
 
         public enum RemoveInfo { MANUAL, FINISHED, REPLACED }
@@ -14,7 +14,7 @@ namespace OwoAdvancedSensationBuilder.manager {
         public event SensationStreamInstanceEvent? LastCalculationOfCycle;
         public event SensationStreamInstanceEvent? AfterUpdate;
         public event SensationStreamInstanceRemoveEvent? AfterRemove;
-        public event SensationStreamInstanceFirstCycleEvent? OnFirstCycle;
+        public event SensationStreamInstanceSensationTickEvent? OnFirstSensationTick;
 
         public string name { get; }
         internal int firstTick { get; set; }
@@ -46,14 +46,13 @@ namespace OwoAdvancedSensationBuilder.manager {
                 return null;
             }
 
-            if (isFirstCalculationCycle)
-            {
+            int playedSensation = (tick - firstTick) % sensation.sensations.Count;
+
+            if (playedSensation == 0) {
+                OnFirstSensationTick?.Invoke(this, isFirstCalculationCycle);
                 isFirstCalculationCycle = false;
-                OnFirstCycle?.Invoke(this);
             }
 
-            int playedSensation = (tick - firstTick) % sensation.sensations.Count;
-            
             if (isLastTickOfCycle(tick)) {
                 // trigger events for the last calculation
                 LastCalculationOfCycle?.Invoke(this);


### PR DESCRIPTION
This PR changes the data type of `playSensations` to a `ConcurrentDictionary` to improve handling of concurrency and simplifies the manager code by removing the current concurrency logic around `processSensation`.

As a result, following parameters have been removed:
*  `addPlanned` in `AdvancedSensationManager.getPlayingSensationInstances`
* `overwriteManagerProcessList` in `AdvancedSensationStreamInstance`
* `AfterAdd` event in `AdvancedSensationStreamInstance`

Additionally, a new parameter `replaceRunning` has been added to `AdvancedSensationStreamInstance.cs`.

